### PR TITLE
allow comma-dangle in multiline

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "standard",
   "rules": {
+    "comma-dangle": ["error", "only-multiline"],
     "semi": [0],
     "space-before-function-paren": [0],
     "prefer-promise-reject-errors": [0],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Allow `comma-dangle` when it is in multi-line scenarios
<!-- Why are these changes necessary? -->

**Why**:
- solves eslint errors in `./src/componentReader.js` at line 27, 84, 133 which lead to husky errors
- This would enable more sensible git diff in some cases (lower lines modified)
<!-- How were these changes implemented? -->